### PR TITLE
feat: prepare v1.5 Formula Mini control-path release

### DIFF
--- a/tianracer_core/launch/tianracer_core.launch
+++ b/tianracer_core/launch/tianracer_core.launch
@@ -34,10 +34,21 @@
       <remap from="tianracer/ackermann_cmd" to="ackermann_cmd"/>
       <remap from="tianracer/debug_cmd" to="debug_cmd" />
       <remap from="tianracer/debug_result" to="debug_result" />
-      <remap from="tianracer/imu" to="imu" />
+      <remap from="tianracer/imu" to="imu_raw" />
       <remap from="tianracer/odom" to="odom" />
       <remap from="tianracer/uwb" to="uwb" />
       <remap from="tianracer/voltage" to="voltage" />
+    </node>
+
+    <!-- imu complementary_filter -->
+    <node pkg="imu_complementary_filter" type="complementary_filter_node" name="complementary_filter_gain_node" output="screen">
+      <param name="do_bias_estimation" value="true"/>
+      <param name="do_adaptive_gain" value="true"/>
+      <param name="use_mag" value="false"/>
+      <param name="gain_acc" value="0.01"/>
+      <param name="gain_mag" value="0.01"/>
+      <remap from="imu/data_raw" to="imu_raw"/>
+      <remap from="imu/data" to="imu"/>
     </node>
 
     <!-- Robot_Localization for odometry ekf fusion-->

--- a/tianracer_core/package.xml
+++ b/tianracer_core/package.xml
@@ -73,6 +73,9 @@
   <exec_depend>tf</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>ackermann_msgs</exec_depend>
+  <exec_depend>imu_complementary_filter</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
+  <exec_depend>tianbot_core</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/tianracer_navigation/script/ackermann_convert_drive.py
+++ b/tianracer_navigation/script/ackermann_convert_drive.py
@@ -1,32 +1,44 @@
 #!/usr/bin/env python3
-# Author: tianbot
-# Description:  Convert ackermann_msgs/AckermannDriveStamped to ackermann_msgs/AckermannDrive
-
+# Author: tianbot (Modified for 50Hz upsampling)
 import rospy
 from ackermann_msgs.msg import AckermannDriveStamped, AckermannDrive
-from geometry_msgs.msg import Twist
 
 class AckermannConverter:
     def __init__(self):
-        rospy.init_node('ackermann_stamped_converter', anonymous=True) 
+        rospy.init_node('ackermann_stamped_converter', anonymous=True)
+        
+        # 参数获取
         ackermann_cmd_topic = rospy.get_param('~ackermann_cmd_topic', 'ackermann_cmd')
         ackermann_stamped_cmd_topic = rospy.get_param('~ackermann_stamped_cmd_topic', 'ackermann_cmd_stamped')
+        
+        # 初始化为空，用于判断是否收到了第一条指令
+        self.latest_drive_msg = None
+        
+        # 发布者
         self.drive_pub = rospy.Publisher(ackermann_cmd_topic, AckermannDrive, queue_size=1)
+        
+        # 订阅者
         rospy.Subscriber(ackermann_stamped_cmd_topic, AckermannDriveStamped, self.convert_callback, queue_size=1)
+        
+        # --- 设定为 50Hz --- ，与下位机超时频率一致
+        # 频率 f = 50, 周期 T = 1/50 = 0.02s
+        self.timer = rospy.Timer(rospy.Duration(1.0/50.0), self.timer_callback)
 
     def convert_callback(self, msg):
-        """callback func"""
+        """将收到的 Stamped 消息解包并存入缓存"""
+        if self.latest_drive_msg is None:
+            self.latest_drive_msg = AckermannDrive()
+            
+        self.latest_drive_msg.speed = msg.drive.speed
+        self.latest_drive_msg.steering_angle = msg.drive.steering_angle
+        self.latest_drive_msg.acceleration = msg.drive.acceleration
+        self.latest_drive_msg.steering_angle_velocity = msg.drive.steering_angle_velocity
+        self.latest_drive_msg.jerk = msg.drive.jerk
 
-        drive_msg = AckermannDrive()
-        
-        # copy the message value
-        drive_msg.speed = msg.drive.speed
-        drive_msg.steering_angle = msg.drive.steering_angle
-        drive_msg.acceleration = msg.drive.acceleration
-        drive_msg.jerk = msg.drive.jerk
-        
-        # post the converted message
-        self.drive_pub.publish(drive_msg)
+    def timer_callback(self, event):
+        """以 50Hz 频率持续发布最新缓存的数据"""
+        if self.latest_drive_msg is not None:
+            self.drive_pub.publish(self.latest_drive_msg)
 
 if __name__ == '__main__':
     try:

--- a/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
+++ b/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import rospy, math

--- a/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
+++ b/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
@@ -1,55 +1,77 @@
 #!/usr/bin/env python
-
-# Author: christoph.roesmann@tu-dortmund.de
+# -*- coding: utf-8 -*-
 
 import rospy, math
 from geometry_msgs.msg import Twist
 from ackermann_msgs.msg import AckermannDrive
 
+# 全局变量
+current_v = 0.0
+current_steering = 0.0
+has_received_data = False
 
 def convert_trans_rot_vel_to_steering_angle(v, omega, wheelbase):
-  if omega == 0 or v == 0:
-    return 0
-
-  radius = v / omega
-  return math.atan(wheelbase / radius)
-
+  # 1. 如果没有角速度输入，转角必为 0
+  if omega == 0:
+    return 0.0
+    
+  # 2. 核心数学转换：增加速度为0时的保护
+  if v == 0:
+    v_eff = 0.1 # 有角速度但没线速度时，给定一个有效线速度计算转角
+  else:
+    v_eff = v
+    
+  # 3. 计算基础转角并乘以放大因子 gain
+  steering = math.atan(wheelbase * omega / v_eff) # 保持弧度输出
+  return steering
 
 def cmd_callback(data):
-  global wheelbase
-  global ackermann_cmd_topic
-  global pub
+  global wheelbase, current_v, current_steering, has_received_data
   
+  has_received_data = True
   v = data.linear.x
-  steering = convert_trans_rot_vel_to_steering_angle(v, data.angular.z, wheelbase)
+  omega = data.angular.z
   
-  msg = AckermannDrive()
-  msg.steering_angle = steering
+  # 计算转角
+  current_steering = convert_trans_rot_vel_to_steering_angle(v, omega, wheelbase)
+  
+  # 速度阈值钳位逻辑
   threshold = 0.5
-  if 0 < v and v < threshold:
+  if 0 < v < threshold:
     v = threshold
-  elif -threshold < v and v < 0:
+  elif -threshold < v < 0:
     v = -threshold
-  msg.speed = v
-  rospy.loginfo("Clamped v: %.3f", v)
-  pub.publish(msg)
+  current_v = v
+
+def timer_callback(event):
+  """以固定 50Hz 频率发布"""
+  global pub, current_v, current_steering, has_received_data
+  
+  if has_received_data:
+    msg = AckermannDrive()
+    msg.speed = current_v
+    msg.steering_angle = current_steering
+    pub.publish(msg)
 
 if __name__ == '__main__': 
   try:
-    
     rospy.init_node('cmd_vel_to_ackermann_drive')
         
-    twist_cmd_topic = rospy.get_param('~twist_cmd_topic', '/cmd_vel') 
-    ackermann_cmd_topic = rospy.get_param('~ackermann_cmd_topic', '/ackermann_cmd')
+    # 参数获取
+    twist_cmd_topic = rospy.get_param('~twist_cmd_topic', 'cmd_vel') 
+    ackermann_cmd_topic = rospy.get_param('~ackermann_cmd_topic', 'ackermann_cmd')
     wheelbase = rospy.get_param('~wheelbase', 1.0)
     
-    rospy.Subscriber(twist_cmd_topic, Twist, cmd_callback, queue_size=1)
-    pub = rospy.Publisher(ackermann_cmd_topic, AckermannDrive, queue_size=1)
     
-    rospy.loginfo("Node 'cmd_vel_to_ackermann_drive' started.\nListening to %s, publishing to %s. wheelbase: %f", "/cmd_vel", ackermann_cmd_topic, wheelbase)
+    pub = rospy.Publisher(ackermann_cmd_topic, AckermannDrive, queue_size=1)
+    rospy.Subscriber(twist_cmd_topic, Twist, cmd_callback, queue_size=1)
+
+    # --- 50Hz 定时器 ---
+    rospy.Timer(rospy.Duration(1.0/50.0), timer_callback)
+    
+    rospy.loginfo("Node started at 50Hz. Wheelbase: %f", wheelbase)
     
     rospy.spin()
     
   except rospy.ROSInterruptException:
     pass
-


### PR DESCRIPTION
## Summary
- merge the small Formula Mini control-path update into `dev`
- keep the new 50Hz command publication path for Formula Mini
- add the missing runtime dependency declarations needed by the updated launch file
- switch the control script shebang to `python3` for ROS Noetic environments

## Included changes
- add IMU complementary filter node wiring in `tianracer_core.launch`
- publish cached ackermann commands at 50Hz in `ackermann_convert_drive.py`
- publish cached `cmd_vel` conversions at 50Hz in `cmd_vel_to_ackermann_drive.py`
- declare `imu_complementary_filter`, `robot_localization`, and `tianbot_core` runtime dependencies in `tianracer_core/package.xml`

## Verification
- `python3 -m py_compile tianracer_navigation/script/ackermann_convert_drive.py tianracer_navigation/script/cmd_vel_to_ackermann_drive.py`
- XML parse check for `tianracer_core/launch/tianracer_core.launch`, `tianracer_core/package.xml`, and `tianracer_navigation/package.xml`
- `source /opt/ros/noetic/setup.bash && catkin_make --pkg tianracer_core tianracer_navigation`

## Notes
- `catkin_make run_tests --pkg tianracer_core tianracer_navigation` is not available in this workspace because these packages do not define a `run_tests` target.
- This PR intentionally does not include larger feature branches such as `mpc`, `integrated_odom`, ROS 2 migration branches, or historical multi-racer refactors.