### PR TITLE
fix: make cmd_vel speed floor configurable

### DIFF
--- a/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
+++ b/tianracer_navigation/script/cmd_vel_to_ackermann_drive.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import rospy, math
+import math
+import rospy
 from geometry_msgs.msg import Twist
 from ackermann_msgs.msg import AckermannDrive
 
@@ -10,68 +11,84 @@ current_v = 0.0
 current_steering = 0.0
 has_received_data = False
 
+
 def convert_trans_rot_vel_to_steering_angle(v, omega, wheelbase):
   # 1. 如果没有角速度输入，转角必为 0
   if omega == 0:
     return 0.0
-    
+
   # 2. 核心数学转换：增加速度为0时的保护
   if v == 0:
-    v_eff = 0.1 # 有角速度但没线速度时，给定一个有效线速度计算转角
+    v_eff = 0.1  # 有角速度但没线速度时，给定一个有效线速度计算转角
   else:
     v_eff = v
-    
+
   # 3. 计算基础转角并乘以放大因子 gain
-  steering = math.atan(wheelbase * omega / v_eff) # 保持弧度输出
+  steering = math.atan(wheelbase * omega / v_eff)  # 保持弧度输出
   return steering
 
+
+def apply_min_speed_threshold(v, threshold):
+  if threshold <= 0:
+    return v
+
+  if 0 < v < threshold:
+    return threshold
+
+  if -threshold < v < 0:
+    return -threshold
+
+  return v
+
+
 def cmd_callback(data):
-  global wheelbase, current_v, current_steering, has_received_data
-  
+  global wheelbase, min_speed_threshold, current_v, current_steering, has_received_data
+
   has_received_data = True
   v = data.linear.x
   omega = data.angular.z
-  
+
   # 计算转角
   current_steering = convert_trans_rot_vel_to_steering_angle(v, omega, wheelbase)
-  
-  # 速度阈值钳位逻辑
-  threshold = 0.5
-  if 0 < v < threshold:
-    v = threshold
-  elif -threshold < v < 0:
-    v = -threshold
-  current_v = v
+
+  # 速度阈值钳位逻辑，默认关闭，仅在明确配置时启用
+  current_v = apply_min_speed_threshold(v, min_speed_threshold)
+
 
 def timer_callback(event):
   """以固定 50Hz 频率发布"""
   global pub, current_v, current_steering, has_received_data
-  
+
   if has_received_data:
     msg = AckermannDrive()
     msg.speed = current_v
     msg.steering_angle = current_steering
     pub.publish(msg)
 
-if __name__ == '__main__': 
+
+if __name__ == '__main__':
   try:
     rospy.init_node('cmd_vel_to_ackermann_drive')
-        
+
     # 参数获取
-    twist_cmd_topic = rospy.get_param('~twist_cmd_topic', 'cmd_vel') 
+    twist_cmd_topic = rospy.get_param('~twist_cmd_topic', 'cmd_vel')
     ackermann_cmd_topic = rospy.get_param('~ackermann_cmd_topic', 'ackermann_cmd')
     wheelbase = rospy.get_param('~wheelbase', 1.0)
-    
-    
+    min_speed_threshold = rospy.get_param('~min_speed_threshold', 0.0)
+
     pub = rospy.Publisher(ackermann_cmd_topic, AckermannDrive, queue_size=1)
     rospy.Subscriber(twist_cmd_topic, Twist, cmd_callback, queue_size=1)
 
     # --- 50Hz 定时器 ---
-    rospy.Timer(rospy.Duration(1.0/50.0), timer_callback)
-    
-    rospy.loginfo("Node started at 50Hz. Wheelbase: %f", wheelbase)
-    
+    rospy.Timer(rospy.Duration(1.0 / 50.0), timer_callback)
+
+    rospy.loginfo(
+      "Node started at 50Hz. Wheelbase: %f, min_speed_threshold: %f",
+      wheelbase,
+      min_speed_threshold,
+    )
+
     rospy.spin()
-    
+
   except rospy.ROSInterruptException:
     pass


### PR DESCRIPTION
## Summary
- remove the hard-coded 0.5m/s floor from the 50Hz cmd_vel conversion path
- add a  ROS param so low-speed clamping is opt-in per launch/config
- keep the 50Hz republish behavior unchanged while preserving upstream low-speed intent by default

## Testing
- python3 -m py_compile tianracer_navigation/script/cmd_vel_to_ackermann_drive.py tianracer_navigation/script/ackermann_convert_drive.py

Closes #78